### PR TITLE
Implement multi-client WebSocket support with session management

### DIFF
--- a/src/routes/websocket-session.handler.ts
+++ b/src/routes/websocket-session.handler.ts
@@ -1,0 +1,60 @@
+import type { FastifyRequest, FastifyReply } from 'fastify'
+import { z } from 'zod'
+import { WebSocketManagerService } from '../services/websocket/websocket-manager.service.js'
+import { UrlException } from '../services/url/url.exceptions.js'
+import { HttpStatus } from './http-status.js'
+
+interface RegisterSessionRequest {
+  sessionId: string
+  clientId: string
+}
+
+const registerSessionSchema = z.object({
+  sessionId: z.string().min(1, 'Session ID is required'),
+  clientId: z.string().min(1, 'Client ID is required'),
+})
+
+/**
+ * Handler for POST /ws/register-session - WebSocket session registration
+ */
+export class WebSocketSessionHandler {
+  constructor(private readonly wsManager: WebSocketManagerService) {}
+
+  async registerSession(
+    request: FastifyRequest<{ Body: RegisterSessionRequest }>,
+    reply: FastifyReply,
+  ): Promise<void> {
+    try {
+      const validatedBody = registerSessionSchema.parse(request.body)
+      const { sessionId, clientId } = validatedBody
+
+      // Associate session with client
+      this.wsManager.associateSession(sessionId, clientId)
+
+      console.log(`Session ${sessionId} associated with client ${clientId}`)
+
+      return reply.send({
+        message: 'Session registered successfully',
+        sessionId,
+        clientId,
+        stats: this.wsManager.getStats(),
+      })
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new UrlException('URL001', HttpStatus.BAD_REQUEST, {
+          validationErrors: error.errors,
+        })
+      }
+      throw error
+    }
+  }
+
+  async getStats(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+    const stats = this.wsManager.getStats()
+
+    return reply.send({
+      message: 'WebSocket statistics',
+      ...stats,
+    })
+  }
+}

--- a/src/services/websocket/multi-client-manager.service.ts
+++ b/src/services/websocket/multi-client-manager.service.ts
@@ -1,0 +1,171 @@
+import { nanoid } from 'nanoid'
+import type { WebSocket } from 'ws'
+import type { ClientConnection, ClientRegistry } from '../../types/websocket.types.js'
+
+/**
+ * Manages multiple WebSocket client connections
+ */
+export class MultiClientManager {
+  private clients: ClientRegistry = {}
+  private heartbeatInterval: NodeJS.Timeout | null = null
+  private readonly HEARTBEAT_INTERVAL = 30000 // 30 seconds
+
+  constructor() {
+    this.startHeartbeat()
+  }
+
+  /**
+   * Adds a new client connection
+   */
+  addClient(websocket: WebSocket): string {
+    const clientId = nanoid()
+    const connection: ClientConnection = {
+      id: clientId,
+      websocket,
+      connectedAt: new Date(),
+      lastActivity: new Date(),
+    }
+
+    this.clients[clientId] = connection
+    console.log(`Client ${clientId} connected. Total clients: ${this.getClientCount()}`)
+    return clientId
+  }
+
+  /**
+   * Removes a client connection
+   */
+  removeClient(clientId: string): void {
+    if (this.clients[clientId]) {
+      delete this.clients[clientId]
+      console.log(`Client ${clientId} disconnected. Total clients: ${this.getClientCount()}`)
+    }
+  }
+
+  /**
+   * Gets a client connection by ID
+   */
+  getClient(clientId: string): ClientConnection | null {
+    return this.clients[clientId] || null
+  }
+
+  /**
+   * Gets all active client connections
+   */
+  getAllClients(): ClientConnection[] {
+    return Object.values(this.clients)
+  }
+
+  /**
+   * Gets the count of active clients
+   */
+  getClientCount(): number {
+    return Object.keys(this.clients).length
+  }
+
+  /**
+   * Updates client activity timestamp
+   */
+  updateClientActivity(clientId: string): void {
+    const client = this.clients[clientId]
+    if (client) {
+      client.lastActivity = new Date()
+    }
+  }
+
+  /**
+   * Checks if a client exists and is connected
+   */
+  hasClient(clientId: string): boolean {
+    const client = this.clients[clientId]
+    return !!(client && client.websocket.readyState === client.websocket.OPEN)
+  }
+
+  /**
+   * Sends a message to a specific client
+   */
+  sendToClient(clientId: string, message: string): boolean {
+    const client = this.clients[clientId]
+    if (!client || client.websocket.readyState !== client.websocket.OPEN) {
+      return false
+    }
+
+    try {
+      client.websocket.send(message)
+      this.updateClientActivity(clientId)
+      return true
+    } catch (error) {
+      console.error(`Failed to send message to client ${clientId}:`, error)
+      this.removeClient(clientId)
+      return false
+    }
+  }
+
+  /**
+   * Broadcasts a message to all connected clients
+   */
+  broadcastToAll(message: string): void {
+    const clients = this.getAllClients()
+    clients.forEach((client) => {
+      this.sendToClient(client.id, message)
+    })
+  }
+
+  /**
+   * Starts heartbeat mechanism to detect disconnected clients
+   */
+  private startHeartbeat(): void {
+    this.heartbeatInterval = setInterval(() => {
+      const now = new Date()
+      const staleClients: string[] = []
+
+      Object.values(this.clients).forEach((client) => {
+        if (client.websocket.readyState !== client.websocket.OPEN) {
+          staleClients.push(client.id)
+        } else {
+          // Check for inactive clients (no activity for 5 minutes)
+          const inactiveTime = now.getTime() - client.lastActivity.getTime()
+          if (inactiveTime > 300000) {
+            // 5 minutes
+            try {
+              client.websocket.ping()
+              this.updateClientActivity(client.id)
+            } catch (error) {
+              console.error(`Ping failed for client ${client.id}:`, error)
+              staleClients.push(client.id)
+            }
+          }
+        }
+      })
+
+      // Remove stale clients
+      staleClients.forEach((clientId) => {
+        this.removeClient(clientId)
+      })
+    }, this.HEARTBEAT_INTERVAL)
+  }
+
+  /**
+   * Stops heartbeat mechanism
+   */
+  private stopHeartbeat(): void {
+    if (this.heartbeatInterval) {
+      clearInterval(this.heartbeatInterval)
+      this.heartbeatInterval = null
+    }
+  }
+
+  /**
+   * Closes all client connections and cleanup
+   */
+  closeAll(): void {
+    Object.values(this.clients).forEach((client) => {
+      try {
+        client.websocket.terminate()
+      } catch (error) {
+        console.error(`Error terminating client ${client.id}:`, error)
+      }
+    })
+    this.clients = {}
+    this.stopHeartbeat()
+  }
+}

--- a/src/types/websocket.types.ts
+++ b/src/types/websocket.types.ts
@@ -4,9 +4,21 @@
 
 export interface PendingMessage {
   id: string
+  clientId: string
   data: { shortenedURL: string }
   attempts: number
   lastAttempt: Date
+}
+
+export interface ClientConnection {
+  id: string
+  websocket: import('ws').WebSocket
+  connectedAt: Date
+  lastActivity: Date
+}
+
+export interface ClientRegistry {
+  [clientId: string]: ClientConnection
 }
 
 export interface RetryConfig {

--- a/tests/helpers/test-server.ts
+++ b/tests/helpers/test-server.ts
@@ -109,6 +109,10 @@ export class TestServer {
     this.wsManager = wsManager
 
     await app.listen({ port: 0, host: '127.0.0.1' })
+    
+    // Wait for WebSocket server to be ready
+    await wsManager.waitForReady()
+    
     this.isListening = true
   }
 

--- a/tests/unit/multi-client-websocket.test.ts
+++ b/tests/unit/multi-client-websocket.test.ts
@@ -1,0 +1,295 @@
+import { WebSocketServer } from 'ws'
+import { MultiClientManager } from '../../src/services/websocket/multi-client-manager.service.js'
+import { ConnectionHandler } from '../../src/services/websocket/connection.handler.js'
+import { MessageHandler } from '../../src/services/websocket/message.handler.js'
+import { WebSocketManagerService } from '../../src/services/websocket/websocket-manager.service.js'
+import WebSocket from 'ws'
+
+describe('Multi-Client WebSocket Implementation', () => {
+  let wsManager: WebSocketManagerService
+  let wsPort: number
+
+  beforeEach(() => {
+    wsPort = 3002 + Math.floor(Math.random() * 1000)
+    wsManager = new WebSocketManagerService(wsPort)
+  })
+
+  afterEach(async () => {
+    await wsManager.close()
+  })
+
+  describe('MultiClientManager', () => {
+    let clientManager: MultiClientManager
+    let mockWebSocket: WebSocket
+
+    beforeEach(() => {
+      clientManager = new MultiClientManager()
+      mockWebSocket = {
+        readyState: WebSocket.OPEN,
+        send: jest.fn(),
+        ping: jest.fn(),
+        terminate: jest.fn(),
+        OPEN: WebSocket.OPEN,
+      } as any
+    })
+
+    afterEach(() => {
+      clientManager.closeAll()
+    })
+
+    it('should add and track multiple clients', () => {
+      const client1Id = clientManager.addClient(mockWebSocket)
+      const client2Id = clientManager.addClient(mockWebSocket)
+
+      expect(client1Id).toBeDefined()
+      expect(client2Id).toBeDefined()
+      expect(client1Id).not.toBe(client2Id)
+      expect(clientManager.getClientCount()).toBe(2)
+    })
+
+    it('should remove clients correctly', () => {
+      const clientId = clientManager.addClient(mockWebSocket)
+      expect(clientManager.getClientCount()).toBe(1)
+
+      clientManager.removeClient(clientId)
+      expect(clientManager.getClientCount()).toBe(0)
+      expect(clientManager.getClient(clientId)).toBeNull()
+    })
+
+    it('should check client existence', () => {
+      const clientId = clientManager.addClient(mockWebSocket)
+      expect(clientManager.hasClient(clientId)).toBe(true)
+
+      clientManager.removeClient(clientId)
+      expect(clientManager.hasClient(clientId)).toBe(false)
+    })
+
+    it('should send message to specific client', () => {
+      const clientId = clientManager.addClient(mockWebSocket)
+      const message = JSON.stringify({ test: 'message' })
+
+      const result = clientManager.sendToClient(clientId, message)
+      expect(result).toBe(true)
+      expect(mockWebSocket.send).toHaveBeenCalledWith(message)
+    })
+
+    it('should return false when sending to non-existent client', () => {
+      const result = clientManager.sendToClient('non-existent', 'message')
+      expect(result).toBe(false)
+    })
+
+    it('should broadcast to all clients', () => {
+      const mockWs1 = { ...mockWebSocket, send: jest.fn() }
+      const mockWs2 = { ...mockWebSocket, send: jest.fn() }
+
+      clientManager.addClient(mockWs1 as any)
+      clientManager.addClient(mockWs2 as any)
+
+      const message = 'broadcast message'
+      clientManager.broadcastToAll(message)
+
+      expect(mockWs1.send).toHaveBeenCalledWith(message)
+      expect(mockWs2.send).toHaveBeenCalledWith(message)
+    })
+  })
+
+  describe('Connection Handler', () => {
+    let connectionHandler: ConnectionHandler
+    let mockWebSocket: WebSocket
+
+    beforeEach(() => {
+      connectionHandler = new ConnectionHandler()
+      mockWebSocket = {
+        on: jest.fn(),
+        readyState: WebSocket.OPEN,
+        OPEN: WebSocket.OPEN,
+      } as any
+    })
+
+    afterEach(() => {
+      connectionHandler.closeAllClients()
+    })
+
+    it('should handle new connection and return client ID', () => {
+      const onMessage = jest.fn()
+      const clientId = connectionHandler.handleConnection(mockWebSocket, onMessage)
+
+      expect(clientId).toBeDefined()
+      expect(typeof clientId).toBe('string')
+      expect(connectionHandler.getConnectedClientCount()).toBe(1)
+    })
+
+    it('should set up WebSocket event listeners', () => {
+      const onMessage = jest.fn()
+      connectionHandler.handleConnection(mockWebSocket, onMessage)
+
+      expect(mockWebSocket.on).toHaveBeenCalledWith('message', expect.any(Function))
+      expect(mockWebSocket.on).toHaveBeenCalledWith('close', expect.any(Function))
+      expect(mockWebSocket.on).toHaveBeenCalledWith('error', expect.any(Function))
+      expect(mockWebSocket.on).toHaveBeenCalledWith('pong', expect.any(Function))
+    })
+
+    it('should support multiple concurrent connections', () => {
+      const mockWs1 = { ...mockWebSocket, on: jest.fn() }
+      const mockWs2 = { ...mockWebSocket, on: jest.fn() }
+
+      const clientId1 = connectionHandler.handleConnection(mockWs1 as any, jest.fn())
+      const clientId2 = connectionHandler.handleConnection(mockWs2 as any, jest.fn())
+
+      expect(clientId1).not.toBe(clientId2)
+      expect(connectionHandler.getConnectedClientCount()).toBe(2)
+    })
+  })
+
+  describe('Message Handler', () => {
+    let messageHandler: MessageHandler
+    let clientManager: MultiClientManager
+    let mockWebSocket: WebSocket
+
+    beforeEach(() => {
+      clientManager = new MultiClientManager()
+      messageHandler = new MessageHandler(clientManager)
+      mockWebSocket = {
+        readyState: WebSocket.OPEN,
+        send: jest.fn(),
+        OPEN: WebSocket.OPEN,
+      } as any
+    })
+
+    afterEach(() => {
+      clientManager.closeAll()
+    })
+
+    it('should send message to specific client', () => {
+      const clientId = clientManager.addClient(mockWebSocket)
+      const shortenedUrl = 'http://short.ly/abc123'
+
+      messageHandler.sendShortenedUrl(clientId, shortenedUrl)
+
+      expect(mockWebSocket.send).toHaveBeenCalledWith(expect.stringContaining(shortenedUrl))
+    })
+
+    it('should track pending messages with client ID', () => {
+      const clientId = clientManager.addClient(mockWebSocket)
+      const shortenedUrl = 'http://short.ly/abc123'
+
+      messageHandler.sendShortenedUrl(clientId, shortenedUrl)
+
+      const pendingMessages = messageHandler.getPendingMessages()
+      expect(pendingMessages).toHaveLength(1)
+      expect(pendingMessages[0].clientId).toBe(clientId)
+      expect(pendingMessages[0].data.shortenedURL).toBe(shortenedUrl)
+    })
+
+    it('should handle acknowledgment correctly', () => {
+      const clientId = clientManager.addClient(mockWebSocket)
+      messageHandler.sendShortenedUrl(clientId, 'http://short.ly/abc123')
+
+      const pendingMessages = messageHandler.getPendingMessages()
+      expect(pendingMessages).toHaveLength(1)
+
+      const messageId = pendingMessages[0].id
+      messageHandler.handleAcknowledgment(messageId, clientId)
+
+      expect(messageHandler.getPendingMessages()).toHaveLength(0)
+    })
+  })
+
+  describe('WebSocket Manager Service', () => {
+    it('should support multiple concurrent connections', (done: any) => {
+      const clients: WebSocket[] = []
+      const clientIds: string[] = []
+
+      // Create multiple WebSocket connections
+      for (let i = 0; i < 3; i++) {
+        const ws = new WebSocket(`ws://localhost:${wsPort}`)
+        clients.push(ws)
+
+        ws.on('open', () => {
+          // Register each connection with a session
+          const sessionId = `session-${i}`
+          const clientId = `client-${i}`
+
+          fetch(`http://localhost:3000/ws/register-session`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ sessionId, clientId }),
+          }).catch(() => {
+            // Registration endpoint might not be available in test
+          })
+
+          clientIds.push(clientId)
+
+          if (clients.length === 3 && clients.every((c) => c.readyState === WebSocket.OPEN)) {
+            expect(wsManager.getConnectedClientCount()).toBe(3)
+
+            // Cleanup
+            clients.forEach((c) => c.close())
+            done()
+          }
+        })
+
+        ws.on('error', (error) => {
+          console.error('WebSocket error:', error)
+        })
+      }
+    })
+
+    it('should maintain connection statistics', async () => {
+      const stats = wsManager.getStats()
+      expect(stats).toHaveProperty('connectedClients')
+      expect(stats).toHaveProperty('pendingMessages')
+      expect(stats).toHaveProperty('activeSessions')
+      expect(typeof stats.connectedClients).toBe('number')
+      expect(typeof stats.pendingMessages).toBe('number')
+      expect(typeof stats.activeSessions).toBe('number')
+    })
+
+    it('should handle session association', () => {
+      const sessionId = 'test-session'
+      const clientId = 'test-client'
+
+      wsManager.associateSession(sessionId, clientId)
+
+      const stats = wsManager.getStats()
+      expect(stats.activeSessions).toBe(1)
+    })
+  })
+
+  describe('Integration Tests', () => {
+    it('should handle complete multi-client workflow', (done: any) => {
+      const client1 = new WebSocket(`ws://localhost:${wsPort}`)
+      const client2 = new WebSocket(`ws://localhost:${wsPort}`)
+
+      let client1Ready = false
+      let client2Ready = false
+
+      client1.on('open', () => {
+        client1Ready = true
+        checkBothReady()
+      })
+
+      client2.on('open', () => {
+        client2Ready = true
+        checkBothReady()
+      })
+
+      function checkBothReady() {
+        if (client1Ready && client2Ready) {
+          expect(wsManager.getConnectedClientCount()).toBe(2)
+
+          // Test that both clients remain connected
+          setTimeout(() => {
+            expect(wsManager.getConnectedClientCount()).toBe(2)
+            client1.close()
+            client2.close()
+            done()
+          }, 100)
+        }
+      }
+
+      client1.on('error', done)
+      client2.on('error', done)
+    })
+  })
+})


### PR DESCRIPTION
- Replace single-client WebSocket limitation with multi-client architecture
- Add MultiClientManager for tracking multiple concurrent connections
- Implement session-based targeted messaging with fallback mechanisms
- Update ConnectionHandler, MessageHandler, and RetryHandler for multi-client support
- Add WebSocket session registration API endpoints
- Maintain backward compatibility with fallback to any available client
- Enable special characters URL test that was previously skipped
- All E2E tests passing with robust multi-client implementation